### PR TITLE
fix: package.json scripts are removed from published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cultureamp/datadog-cdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "CDK constructs for DataDog Cloudformation resources.",
   "packageManager": "pnpm@8.5.1",
   "files": [
@@ -12,7 +12,7 @@
     ".": "./dist/index.js"
   },
   "scripts": {
-    "prebuildpackage": "pnpm run clean && pnpm run build --project tsconfig.dist.json",
+    "prebuildpackage": "pnpm run clean && pnpm run build --project tsconfig.dist.json && npm pkg delete scripts",
     "preinstall": "npx only-allow pnpm",
     "build": "tsc",
     "clean": "tsc --build --clean && (rm -rf dist || true)",


### PR DESCRIPTION
## Purpose
- Fixes failing `yarn install` executions by removing all scripts from the published package

## Context
- Fixes these sorts of issues
![image](https://github.com/user-attachments/assets/35cc5662-42f2-4b07-94e2-cb00c01da4f7)
