### PR TITLE
chore: test runner ignores `dist/` directory

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -159,9 +159,10 @@ export default {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  testPathIgnorePatterns: [
+    "/dist/",
+    //   "/node_modules/"
+  ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],


### PR DESCRIPTION
# Summary

Running `pnpm build` followed by `pnpm test` will result in failing tests as jest will mistake `dist/__tests__/slo.test.d.ts` for a test file, and fails on it with "no tests detected".

This PR fixes that by having jest ignore files in `dist/`. This includes `dist/__tests__/slo.test.js` which is the tsc-compiled `__tests__/slo.test.ts` running it only benefits us by testing the module resolution of the compiled js - not something I think we're keen on testing.
